### PR TITLE
Fix typo in security.py

### DIFF
--- a/fastapi-alembic-sqlmodel-async/app/core/security.py
+++ b/fastapi-alembic-sqlmodel-async/app/core/security.py
@@ -33,7 +33,7 @@ def create_refresh_token(
         expire = datetime.utcnow() + expires_delta
     else:
         expire = datetime.utcnow() + timedelta(
-            minutes=settings.REFRES_TOKEN_EXPIRE_MINUTES
+            minutes=settings.REFRESH_TOKEN_EXPIRE_MINUTES
         )
     to_encode = {"exp": expire, "sub": str(subject),"type": "refresh"}
     encoded_jwt = jwt.encode(to_encode, settings.SECRET_KEY, algorithm=ALGORITHM)


### PR DESCRIPTION
I've found a Typo in the security.py file. The settings.REFRES_TOKEN_EXPIRE_MINUTES should be REFRESH_TOKEN_EXPIRE_MINUTES.