### PR TITLE
Fix uvicorn not reloading after applying changes

### DIFF
--- a/fastapi-alembic-sqlmodel-async/poetry.lock
+++ b/fastapi-alembic-sqlmodel-async/poetry.lock
@@ -43,8 +43,8 @@ idna = ">=2.8"
 sniffio = ">=1.1"
 
 [package.extras]
-doc = ["packaging", "sphinx-rtd-theme", "sphinx-autodoc-typehints (>=1.2.0)"]
-test = ["coverage[toml] (>=4.5)", "hypothesis (>=4.0)", "pytest (>=7.0)", "pytest-mock (>=3.6.1)", "trustme", "contextlib2", "uvloop (<0.15)", "mock (>=4)", "uvloop (>=0.15)"]
+doc = ["packaging", "sphinx-autodoc-typehints (>=1.2.0)", "sphinx-rtd-theme"]
+test = ["contextlib2", "coverage[toml] (>=4.5)", "hypothesis (>=4.0)", "mock (>=4)", "pytest (>=7.0)", "pytest-mock (>=3.6.1)", "trustme", "uvloop (<0.15)", "uvloop (>=0.15)"]
 trio = ["trio (>=0.16)"]
 
 [[package]]

--- a/fastapi-alembic-sqlmodel-async/pyproject.toml
+++ b/fastapi-alembic-sqlmodel-async/pyproject.toml
@@ -22,6 +22,7 @@ fastapi-async-sqlalchemy = "^0.3.12"
 aioredis = "^2.0.1"
 minio = "^7.1.12"
 Pillow = "^9.2.0"
+watchfiles = "^0.18.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"


### PR DESCRIPTION
While running the server via `make run-dev`, changes applied to the code should reload the server automatically, but it doesn't.

The problem was caused by `watchfiles` not being added to poetry dependencies.