### PR TITLE
Fix: aioredis release version 2.0.1 cannot support python 3.11

### DIFF
--- a/fastapi-alembic-sqlmodel-async/Dockerfile
+++ b/fastapi-alembic-sqlmodel-async/Dockerfile
@@ -1,4 +1,4 @@
-FROM tiangolo/uvicorn-gunicorn-fastapi:latest
+FROM tiangolo/uvicorn-gunicorn-fastapi:python3.10-2022-11-25
 ENV PYTHONUNBUFFERED=1
 WORKDIR /code
 # Install Poetry


### PR DESCRIPTION
tiangolo/uvicorn-gunicorn-fastapi:latest use python 3.11, but aioredis cannot support this.

Signed-off-by: Dee.H.Y <dongfengweixiao@hotmail.com>