### PR TITLE
Migrate from passlib to bcrypt

### DIFF
--- a/backend/app/app/api/deps.py
+++ b/backend/app/app/api/deps.py
@@ -1,21 +1,21 @@
 from collections.abc import AsyncGenerator
 from typing import Callable
-from fastapi import Depends, HTTPException, status
-from app.utils.token import get_valid_tokens
-from app.utils.minio_client import MinioClient
-from fastapi.security import OAuth2PasswordBearer
-from jose import jwt
-from app.models.user_model import User
-from pydantic import ValidationError
-from app import crud
-from app.core import security
-from app.core.config import settings
-from app.db.session import SessionLocal, SessionLocalCelery
-from sqlmodel.ext.asyncio.session import AsyncSession
-from app.schemas.common_schema import IMetaGeneral, TokenType
-import redis.asyncio as aioredis
-from redis.asyncio import Redis
 
+import redis.asyncio as aioredis
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+from jwt import DecodeError, ExpiredSignatureError, MissingRequiredClaimError
+from redis.asyncio import Redis
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app import crud
+from app.core.config import settings
+from app.core.security import decode_token
+from app.db.session import SessionLocal, SessionLocalCelery
+from app.models.user_model import User
+from app.schemas.common_schema import IMetaGeneral, TokenType
+from app.utils.minio_client import MinioClient
+from app.utils.token import get_valid_tokens
 
 reusable_oauth2 = OAuth2PasswordBearer(
     tokenUrl=f"{settings.API_V1_STR}/login/access-token"
@@ -49,23 +49,32 @@ async def get_general_meta() -> IMetaGeneral:
 
 def get_current_user(required_roles: list[str] = None) -> Callable[[], User]:
     async def current_user(
-        token: str = Depends(reusable_oauth2),
+        access_token: str = Depends(reusable_oauth2),
         redis_client: Redis = Depends(get_redis_client),
     ) -> User:
         try:
-            payload = jwt.decode(
-                token, settings.SECRET_KEY, algorithms=[security.ALGORITHM]
-            )
-        except (jwt.JWTError, ValidationError):
+            payload = decode_token(access_token)
+        except ExpiredSignatureError:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
-                detail="Could not validate credentials",
+                detail="Your token has expired. Please log in again.",
             )
+        except DecodeError:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Error when decoding the token. Please check your request.",
+            )
+        except MissingRequiredClaimError:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="There is no required field in your token. Please contact the administrator.",
+            )
+
         user_id = payload["sub"]
         valid_access_tokens = await get_valid_tokens(
             redis_client, user_id, TokenType.ACCESS
         )
-        if valid_access_tokens and token not in valid_access_tokens:
+        if valid_access_tokens and access_token not in valid_access_tokens:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Could not validate credentials",

--- a/backend/app/pyproject.toml
+++ b/backend/app/pyproject.toml
@@ -44,9 +44,9 @@ alembic = "^1.10.2"
 asyncpg = "^0.27.0"
 fastapi = {extras = ["all"], version = "^0.95.2"}
 sqlmodel = "^0.0.8"
-python-jose = "^3.3.0"
 cryptography = "^38.0.3"
-passlib = "^1.7.4"
+bcrypt = "^4.0.1"
+pyjwt = { extras = ["crypto"], version = "^2.8.0" }
 SQLAlchemy-Utils = "^0.38.3"
 SQLAlchemy = "^1.4.40"
 fastapi-pagination = {extras = ["sqlalchemy"], version = "^0.11.4"}

--- a/backend/app/pyproject.toml
+++ b/backend/app/pyproject.toml
@@ -44,7 +44,7 @@ alembic = "^1.10.2"
 asyncpg = "^0.27.0"
 fastapi = {extras = ["all"], version = "^0.95.2"}
 sqlmodel = "^0.0.8"
-cryptography = "^38.0.3"
+cryptography = "^41.0.3"
 bcrypt = "^4.0.1"
 pyjwt = { extras = ["crypto"], version = "^2.8.0" }
 SQLAlchemy-Utils = "^0.38.3"


### PR DESCRIPTION
The **passlib** library has not been supported since October 2020 and depends on the **crypt** libraries, which will be removed in python 3.13. 
The **python-jose** library has not been supported since June 2021. 

In this pull request, I made the transition from the **passlib** library to **bcrypt** and from the **python-jose** library to **PyJWT**. These libraries have constant support and are in demand by the community